### PR TITLE
Handle Unknown Player

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,4 +3,8 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
   before_action :authenticate_user!
+
+  def not_found
+     raise ActionController::RoutingError.new('Not Found')
+  end
 end

--- a/app/controllers/game/sessions_controller.rb
+++ b/app/controllers/game/sessions_controller.rb
@@ -11,11 +11,19 @@ class Game::SessionsController < ApplicationController
   end
 
   def create
+    players = params[:session_players]
+    identified_players = players.select { |p| p[:player_id].to_i > 0 }
+
+    # Only allow duplicate unknown players
+    if identified_players.map { |p| p[:player_id] }.uniq.length != identified_players.length
+      raise ActionController::BadRequest.new('Duplicate Players')
+    end
+
     @session = Session.new
     @session.game_id = params[:game_id]
     @session.save
 
-    params[:session_players].each do |player|
+    players.each do |player|
       @session_player = SessionPlayer.new
       @session_player.session_id = @session.id
       @session_player.player_id = player[:player_id]

--- a/app/controllers/players_controller.rb
+++ b/app/controllers/players_controller.rb
@@ -1,13 +1,13 @@
 class PlayersController < ApplicationController
   def index
-    @players = Player.all
+    @players = get_filtered_players
   end
 
   def new
   end
 
   def list
-    players = Player.all
+    players = get_filtered_players
     render :json => players
   end
 
@@ -27,5 +27,9 @@ class PlayersController < ApplicationController
   private
     def player_params
       params.require(:player).permit(:name, :powers)
+    end
+
+    def get_filtered_players
+      Player.all.select { |player| player.id > 0 }
     end
 end

--- a/app/controllers/players_controller.rb
+++ b/app/controllers/players_controller.rb
@@ -18,7 +18,10 @@ class PlayersController < ApplicationController
   end
 
   def show
-    @player = Player.find(params[:id])
+    session_id = params[:id].to_i
+    not_found if session_id < 0
+
+    @player = Player.find(session_id)
   end
 
   private

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,10 +1,7 @@
 # This file should contain all the record creation needed to seed the database with its default values.
 # The data can then be loaded with the rake db:seed (or created alongside the db with db:setup).
 #
-# Examples:
-#
-#   cities = City.create([{ name: 'Chicago' }, { name: 'Copenhagen' }])
-#   Mayor.create(name: 'Emanuel', city: cities.first)
+# Note: Keep this file idempotent as it will be run after every build
 
 unless Rails.env == 'production'
   #Create basic user in non-production environments
@@ -13,3 +10,7 @@ unless Rails.env == 'production'
   genesisUser.password_confirmation = 'gametracker'
   genesisUser.save!
 end
+
+unknownPlayer = Player.find_or_create_by(id: -1)
+unknownPlayer.name = 'Unknown'
+unknownPlayer.save!

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,7 +6,10 @@
 #   cities = City.create([{ name: 'Chicago' }, { name: 'Copenhagen' }])
 #   Mayor.create(name: 'Emanuel', city: cities.first)
 
-#Create basic user in non-production environments
 unless Rails.env == 'production'
-  User.create! :email => 'gametracker@example.com', :password => 'gametracker', :password_confirmation => 'gametracker'
+  #Create basic user in non-production environments
+  genesisUser = User.find_or_initialize_by(email: 'gametracker@example.com')
+  genesisUser.password = 'gametracker'
+  genesisUser.password_confirmation = 'gametracker'
+  genesisUser.save!
 end

--- a/test/controllers/players_controller_test.rb
+++ b/test/controllers/players_controller_test.rb
@@ -1,6 +1,20 @@
 require 'test_helper'
 
 class PlayersControllerTest < ActionController::TestCase
+  test 'should not show unknown player in list of players' do
+    get :list
+    def json_response
+      ActiveSupport::JSON.decode @response.body
+    end
+    assert_equal (Player.count - 1), json_response.count
+  end
+
+  test 'should not display unknown player in index of players' do
+    get :index
+
+    assert_equal (Player.count - 1), assigns(:players).count
+  end
+
   test 'should not show unknown user page' do
     assert_raises(ActionController::RoutingError) do
       get(:show, {'id' => players(:unknown).id})
@@ -11,4 +25,5 @@ class PlayersControllerTest < ActionController::TestCase
     get(:show, {'id' => players(:brian).id})
     assert_response :success
   end
+
 end

--- a/test/controllers/players_controller_test.rb
+++ b/test/controllers/players_controller_test.rb
@@ -1,7 +1,14 @@
 require 'test_helper'
 
 class PlayersControllerTest < ActionController::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test 'should not show unknown user page' do
+    assert_raises(ActionController::RoutingError) do
+      get(:show, {'id' => players(:unknown).id})
+    end
+  end
+
+  test 'should show valid players' do
+    get(:show, {'id' => players(:brian).id})
+    assert_response :success
+  end
 end

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -14,6 +14,48 @@ class Game::SessionsControllerTest < ActionController::TestCase
     assert_response :success
   end
 
+  test 'should not be able to add player twice to session' do
+    @session_players = [
+        {
+            'player_id' => players(:josh).id,
+            'placing' => 1,
+            'score' => 2
+        },
+        {
+            'player_id' => players(:josh).id,
+            'placing' => 2,
+            'score' => 1
+        }
+    ]
+
+    assert_raises(ActionController::BadRequest) do
+      post :create, {'game_id' => 1, 'session_players' => @session_players}
+    end
+  end
+
+  test 'should be able to add unknown player multiple times to session' do
+    @session_players = [
+        {
+            'player_id' => players(:brian).id,
+            'placing' => 2,
+            'score' => 1
+        },
+        {
+            'player_id' => players(:unknown).id,
+            'placing' => 1,
+            'score' => 2
+        },
+        {
+            'player_id' => players(:unknown).id,
+            'placing' => 2,
+            'score' => 1
+        }
+    ]
+
+    post :create, {'game_id' => 1, 'session_players' => @session_players}
+    assert_response :success
+  end
+
   # TODO Add this back when show is available
   # test 'should get show' do
   #   get(:show, {'id' => '1'})

--- a/test/fixtures/players.yml
+++ b/test/fixtures/players.yml
@@ -1,5 +1,9 @@
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
+unknown:
+  id: -1
+  name: Uknown
+
 candyce:
   name: Candyce
   powers: Undefeatable


### PR DESCRIPTION
Create an unknown user to serve as a placeholder for players in a session that either are anonymous or you do not want to track.

* Create unknown player (id -1)
* Prevent unknown player id to be navigated to for player pages. `/players/-1`
* Update Sessions controller to prevent duplicate player rows except for the unknown player.

Additionally, when adding the unknown player to the `seeds.rb` file, I made the file idempotent. The rake seeds task should be run on every deploy now.